### PR TITLE
Lookup ADSA server or allow to be provided

### DIFF
--- a/tagreader/__init__.py
+++ b/tagreader/__init__.py
@@ -1,5 +1,5 @@
 from .clients import IMSClient, list_sources  # noqa: F401
-from .odbc_handlers import list_aspen_servers, list_pi_servers  # noqa: F401
+from .odbc_handlers import list_adsa_servers  # noqa: F401
 from .utils import ReaderType, add_statoil_root_certificate  # noqa: F401
 
 try:

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -3,13 +3,15 @@ import pyodbc
 import pandas as pd
 import numpy as np
 import warnings
-from typing import Union
-from .utils import logging, winreg, find_registry_key, ReaderType
+from typing import List, Union
+from .utils import logging, winreg, find_registry_key, list_subkeys, ReaderType
 
 logging.basicConfig(
     format=" %(asctime)s %(levelname)s: %(message)s", level=logging.INFO
 )
 
+ADSA_REGISTRY_PATH = r"Software\AspenTech\ADSA\Caches\\"
+server_registry_path = lambda server: ADSA_REGISTRY_PATH + server + r"\\" + os.getlogin()
 
 def list_aspen_servers():
     warnings.warn(
@@ -30,18 +32,30 @@ def list_pi_servers():
     )
     return list_pi_sources()
 
+def list_adsa_servers() -> List[str]:
+    try:
+        adsa_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, ADSA_REGISTRY_PATH)
+    except:
+        return []
+    return list_subkeys(adsa_key)
 
-def list_aspen_sources():
-    source_list = []
+def list_aspen_sources(server: str = None) -> List[str]:
+    available_servers = list_adsa_servers()
+
+    if server is None:
+        if available_servers:
+            server = available_servers[0]
+        else:
+            print("No ADSA servers available.")
+            return []
+    else:
+        assert server in available_servers
+    
     reg_adsa = winreg.OpenKey(
         winreg.HKEY_CURRENT_USER,
-        r"Software\AspenTech\ADSA\Caches\AspenADSA\\" + os.getlogin(),
+        server_registry_path(server),
     )
-    num_sources, _, _ = winreg.QueryInfoKey(reg_adsa)
-    for i in range(0, num_sources):
-        source_list.append(winreg.EnumKey(reg_adsa, i))
-    return source_list
-
+    return list_subkeys(reg_adsa)
 
 def list_pi_sources():
     source_list = []

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -13,24 +13,6 @@ logging.basicConfig(
 ADSA_REGISTRY_PATH = r"Software\AspenTech\ADSA\Caches\\"
 server_registry_path = lambda server: ADSA_REGISTRY_PATH + server + r"\\" + os.getlogin()
 
-def list_aspen_servers():
-    warnings.warn(
-        (
-            "This function is deprecated and will be removed."
-            "Please call 'list_sources(\"aspen\")' instead"
-        )
-    )
-    return list_aspen_sources()
-
-
-def list_pi_servers():
-    warnings.warn(
-        (
-            "This function is deprecated and will be removed."
-            "Please call 'list_sources(\"pi\")' instead"
-        )
-    )
-    return list_pi_sources()
 
 def list_adsa_servers() -> List[str]:
     try:

--- a/tagreader/utils.py
+++ b/tagreader/utils.py
@@ -4,6 +4,8 @@ import warnings
 import winreg
 import pandas as pd
 
+from typing import List
+from winreg import HKEYType
 
 def find_registry_key(base_key, search_key_name):
     search_key_name = search_key_name.lower()
@@ -39,6 +41,12 @@ def find_registry_key_from_name(base_key, search_key_name):
             logging.error("{}: {}".format(i, err))
     return key, key_string
 
+def list_subkeys(key: HKEYType) -> List[str]:
+    count, *_ = winreg.QueryInfoKey(key)
+    subkeys = []
+    for i in range(count):
+        subkeys.append(winreg.EnumKey(key, i))
+    return subkeys
 
 def ensure_datetime_with_tz(date_stamp, tz="Europe/Oslo"):
     if isinstance(date_stamp, str):


### PR DESCRIPTION
- [x] Issue: Fixes #1 
This PR adds `list_adsa_servers()`, and also adds an optional `server` keyword to the public API. This allows the user to query and select which ADSA registry to use for looking up data sources. If no `server` is provided, the first available server will be used.